### PR TITLE
Navbar height now fits content

### DIFF
--- a/client/src/res/css/nav.css
+++ b/client/src/res/css/nav.css
@@ -10,7 +10,7 @@
   font-family: Arial;
   color: #000000 !important;
   font-weight: bold;
-  height: 40px;
+  height: fit-content;
 }
 
 .nav-link:hover {


### PR DESCRIPTION
Changed height from `40px` to `fit-content`